### PR TITLE
Created deployment scripts for taxi-bot

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+taxi-bot/*
+~taxi-bot/Dockerfile

--- a/scripts/compose-helper.sh
+++ b/scripts/compose-helper.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+exec docker-compose -f $DIR/docker-compose.yml -p "won_transport" $@

--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -10,12 +10,15 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-cp -pf $DIR/../won-taxi-bot/target/taxi-bot.jar $DIR/taxi-bot/taxi-bot.jar
+export DOCKER_HOST=satvm01.researchstudio.at:2376
+export DOCKER_TLS_VERIFY=1
 
-rm -rf $DIR/taxi-bot/conf
-cp -rfp $DIR/../conf $DIR/taxi-bot/conf
+if [ -z "$DOCKER_CERT_PATH" ]; then
+    (>&2 echo "You need to set DOCKER_CERT_PATH to authenticate with the docker daemon!")
+    exit 1
+fi
 
-rm -rf $DIR/taxi-bot/factory-needs/
-cp -rfp $DIR/../won-taxi-bot/src/main/resources/FactoryNeeds $DIR/taxi-bot/factory-needs
+export WON_NODE_BASE=https://node.matchat.org
+export API_USERNAME=asdf #we are currently mocking the api so we only need the username
 
-docker-compose -f $DIR/docker-compose.yml -p "won_transport" up -d --build
+$DIR/deploy.sh

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+cp -pf $DIR/../won-taxi-bot/target/taxi-bot.jar $DIR/taxi-bot/taxi-bot.jar
+
+rm -rf $DIR/taxi-bot/conf
+cp -rfp $DIR/../conf $DIR/taxi-bot/conf
+
+rm -rf $DIR/taxi-bot/factory-needs/
+cp -rfp $DIR/../won-taxi-bot/src/main/resources/FactoryNeeds $DIR/taxi-bot/factory-needs
+
+docker-compose -f $DIR/docker-compose.yml -p "won_transport" up -d --build

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+cp -pf $DIR/../won-taxi-bot/target/taxi-bot.jar $DIR/taxi-bot/taxi-bot.jar
+
+rm -rf $DIR/taxi-bot/conf
+cp -rfp $DIR/../conf $DIR/taxi-bot/conf
+
+rm -rf $DIR/taxi-bot/factory-needs/
+cp -rfp $DIR/../won-taxi-bot/src/main/resources/FactoryNeeds $DIR/taxi-bot/factory-needs
+
+$DIR/compose-helper.sh up -d --build

--- a/scripts/deploy_int.sh
+++ b/scripts/deploy_int.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+export DOCKER_HOST=satvm05.researchstudio.at:2376
+export DOCKER_TLS_VERIFY=1
+
+if [ -z "$DOCKER_CERT_PATH" ]; then
+    (>&2 echo "You need to set DOCKER_CERT_PATH to authenticate with the docker daemon!")
+    exit 1
+fi
+
+export WON_NODE_BASE=https://satvm05.researchstudio.at
+export API_USERNAME=asdf #we are currently mocking the api so we only need the username
+
+$DIR/deploy.sh

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  taxi_bot:
+    build: ./taxi-bot
+    image: webofneeds/taxi_bot
+    environment:
+      - "api.serverUrl=${API_SERVER_URL}"
+      - "api.username=${API_USERNAME}"
+      - "api.password=${API_PASSWORD}"
+      - "uri.node.default=${WON_NODE_BASE}/won/resource"
+      - "won.node.uris=${WON_NODE_BASE}/won/resource"
+      - "uri.prefix.owner=${WON_NODE_BASE}/taxi_bot"  # set this for the trust store alias
+      - "taxibot.name=Taxi Service Bot"
+      - "taxibot.bot.factoryneedfolder=/usr/src/factory-needs"
+
+      # keystore properties
+      - "keystore.password"
+      - "keystore.location=/usr/src/certs/keystore.jks"
+
+      # truststore properties
+      - "truststore.password"
+      - "truststore.location=/usr/src/certs/truststore.jks"
+
+      # mongodb config
+      - "botContext.impl=mongoBotContext"
+      - "botContext.mongodb.user=taxi_bot"
+      - "botContext.mongodb.pass=taxi_bot"
+      - "botContext.mongodb.host=mongodb"
+      - "botContext.mongodb.port=27017"
+      - "botContext.mongodb.database=taxi_bot"
+    depends_on:
+      - mongodb
+    volumes:
+      - "certs:/usr/src/certs"
+
+  mongodb:
+    image: bitnami/mongodb
+    environment:
+      - "MONGODB_USERNAME=taxi_bot"
+      - "MONGODB_PASSWORD=taxi_bot"
+      - "MONGODB_DATABASE=taxi_bot"
+
+volumes:
+  certs:

--- a/scripts/taxi-bot/Dockerfile
+++ b/scripts/taxi-bot/Dockerfile
@@ -1,0 +1,31 @@
+# before docker build can be executed, the jar file and the conf
+# directory have to be copied into this folder (done by maven build)
+
+# use java as a base image
+# fix java version here until the following issue is resolved: https://github.com/researchstudio-sat/webofneeds/issues/1229
+FROM openjdk:8u121-jdk
+
+# add webofneeds default config env variables
+ENV WON_CONFIG_DIR=/usr/src/conf
+ENV LOGBACK_CONFIG=logback.xml
+
+# add the default monitoring output directory
+ENV TAXI_BOT=won.transport.taxi.bot.app.TaxiBotApp
+
+# add the jar and the conf directory
+ADD ./taxi-bot.jar /usr/src/
+ADD ./conf ${WON_CONFIG_DIR}
+ADD ./factory-needs /usr/src/factory-needs
+
+# add certificates directory
+RUN mkdir -p /usr/src/certs
+RUN mkdir -p /usr/src/factory-needs
+
+
+# start echo bot
+WORKDIR /usr/src/
+CMD java -DWON_CONFIG_DIR=${WON_CONFIG_DIR}/ \
+-Dlogback.configurationFile=${WON_CONFIG_DIR}/${LOGBACK_CONFIG} \
+${JMEM_OPTS} \
+${JMX_OPTS} \
+-cp "taxi-bot.jar" ${TAXI_BOT}

--- a/won-taxi-bot/pom.xml
+++ b/won-taxi-bot/pom.xml
@@ -12,6 +12,60 @@
 
     <name>won-taxi-bot</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <id>build-tax-bot-uberjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>taxi-bot</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <artifactSet>
+                                <includes>
+                                    <include>*:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>reference.conf</resource>
+                                </transformer>
+                                <!--transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>won.matcher.service.AkkaSystemMain</mainClass>
+                                </transformer-->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.handlers</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.schemas</resource>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -47,10 +101,12 @@
         <dependency>
             <groupId>at.researchstudio.sat</groupId>
             <artifactId>won-bot</artifactId>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>at.researchstudio.sat</groupId>
             <artifactId>won-utils-goals</artifactId>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This can be tested by running either `scripts/deploy_int.sh` or `scripts/deploy_live.sh`

`scripts/compose_helper.sh` can be used as a shorthand for calling `docker-compose` with the proper flags, but you need to take care to properly set `DOCKER_HOST` etc, otherwise you might not connect to the right docker daemon.

Initially the scripts will complain about a missing `DOCKER_CERT_PATH` environment variable. This needs to be set to a folder containing ca and client certs for the docker remote connection.
You either need to sign a new certificate with the ca on the right vm, or copy the ones from our jekins install. If you need the path, ping me in slack.