### PR TITLE
Fix #2353

### DIFF
--- a/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/agreement/PreconditionMetAction.java
+++ b/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/agreement/PreconditionMetAction.java
@@ -62,6 +62,8 @@ public class PreconditionMetAction extends BaseEventBotAction{
 
             DepartureAddress departureAddress = InformationExtractor.getDepartureAddress(preconditionEventPayload);
             DestinationAddress destinationAddress = InformationExtractor.getDestinationAddress(preconditionEventPayload);
+            String departureName = InformationExtractor.getDepartureName(preconditionEventPayload);
+            String destinationName = InformationExtractor.getDestinationName(preconditionEventPayload);
 
             final ParseableResult checkOrderResponse = new ParseableResult(botContextWrapper.getMobileBooking().checkOrder(departureAddress, destinationAddress));
             final String preconditionUri = ((PreconditionEvent) event).getPreconditionUri();
@@ -70,7 +72,7 @@ public class PreconditionMetAction extends BaseEventBotAction{
                 //TODO: THE LINE BELOW RESULTS IN SENDING AN INVALID MESSAGE, UNTIL THE CORRECT INSTANCE MODEL IS SENT WE JUST SEND A TEXTMESSAGE AND PROPOSE IT
                 //final ConnectionMessageCommandEvent connectionMessageCommandEvent = new ConnectionMessageCommandEvent(connection, preconditionEventPayload.getInstanceModel());
 
-                Model messageToPropose = WonRdfUtils.MessageUtils.textMessage("Ride from " + departureAddress + " to " + destinationAddress + ":\n\n" + checkOrderResponse);
+                Model messageToPropose = WonRdfUtils.MessageUtils.textMessage("Ride from '" + ((departureName != null) ? departureName : destinationAddress) + "' to '" + ((destinationName != null)? destinationName : destinationAddress) + "':\n\n" + checkOrderResponse);
                 final ConnectionMessageCommandEvent connectionMessageCommandEvent = new ConnectionMessageCommandEvent(connection, messageToPropose);
 
                 ctx.getEventBus().subscribe(ConnectionMessageCommandResultEvent.class, new ActionOnFirstEventListener(ctx, new CommandResultFilter(connectionMessageCommandEvent), new BaseEventBotAction(ctx) {

--- a/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/proposal/ProposalAcceptedAction.java
+++ b/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/proposal/ProposalAcceptedAction.java
@@ -50,6 +50,8 @@ public class ProposalAcceptedAction extends BaseEventBotAction {
 
             DepartureAddress departureAddress = InformationExtractor.getDepartureAddress(proposalAcceptedEvent.getPayload());
             DestinationAddress destinationAddress = InformationExtractor.getDestinationAddress(proposalAcceptedEvent.getPayload());
+            String departureName = InformationExtractor.getDepartureName(proposalAcceptedEvent.getPayload());
+            String destinationName = InformationExtractor.getDestinationName(proposalAcceptedEvent.getPayload());
 
             ParseableResult createOrderResult = new ParseableResult(taxiBotContextWrapper.getMobileBooking().createOrder(departureAddress, destinationAddress));
             String orderId = "";
@@ -61,9 +63,15 @@ public class ProposalAcceptedAction extends BaseEventBotAction {
                 WonRdfUtils.MessageUtils.addProposesToCancel(messageModel, agreementUri);
             }else {
                 orderId = createOrderResult.getOrderId().getValue();
-                messageModel = WonRdfUtils.MessageUtils.textMessage("Ride from " + departureAddress + " to " + destinationAddress + ": "
-                        + "Your Order is: " + createOrderResult
-                        +"\n\n....Get into the Taxi when it arrives!");
+                String rideText = "Your Order has been placed!";
+
+                if((departureName != null || departureAddress != null) && (destinationName != null || destinationAddress != null)) {
+                    rideText = "Ride from '" + ((departureName != null) ? departureName : destinationAddress) + "' to '" + ((destinationName != null)? destinationName : destinationAddress) + "':";
+                }
+
+                messageModel = WonRdfUtils.MessageUtils.textMessage(rideText +
+                        "\n\nYour Order is: " + createOrderResult +
+                        "\n\n....Get into the Taxi when it arrives!");
                 taxiBotContextWrapper.addOfferIdForAgreementURI(agreementUri, orderId);
             }
 

--- a/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/proposal/ProposalReceivedAction.java
+++ b/won-taxi-bot/src/main/java/won/transport/taxi/bot/action/proposal/ProposalReceivedAction.java
@@ -76,6 +76,8 @@ public class ProposalReceivedAction extends BaseEventBotAction {
 
                     DepartureAddress departureAddress = InformationExtractor.getDepartureAddress(proposalModel);
                     DestinationAddress destinationAddress = InformationExtractor.getDestinationAddress(proposalModel);
+                    String destinationName = InformationExtractor.getDestinationName(proposalModel);
+                    String departureName = InformationExtractor.getDepartureName(proposalModel);
 
                     final ParseableResult createOrderResponse = new ParseableResult(botContextWrapper.getMobileBooking().createOrder(departureAddress, destinationAddress));
 
@@ -83,8 +85,7 @@ public class ProposalReceivedAction extends BaseEventBotAction {
                         rejectMsg = createOrderResponse.toString();
                     }else {
                         final String orderId = createOrderResponse.getOrderId().getValue();
-                        Model messageModel = WonRdfUtils.MessageUtils.textMessage("Ride from " + departureAddress + " to " + destinationAddress + ": "
-                                + "Has the Order: '"+createOrderResponse + "....Get into the Taxi when it arrives!");
+                        Model messageModel = WonRdfUtils.MessageUtils.textMessage("Ride from '" + ((departureName != null) ? departureName : destinationAddress) + "' to '" + ((destinationName != null)? destinationName : destinationAddress) + "':\n\nHas the Order: '"+createOrderResponse + "....Get into the Taxi when it arrives!");
 
                         WonRdfUtils.MessageUtils.addAccepts(messageModel, proposalUri);
                         ConnectionMessageCommandEvent connectionMessageCommandEvent = new ConnectionMessageCommandEvent(con, messageModel);

--- a/won-taxi-bot/src/main/java/won/transport/taxi/bot/service/InformationExtractor.java
+++ b/won-taxi-bot/src/main/java/won/transport/taxi/bot/service/InformationExtractor.java
@@ -26,6 +26,7 @@ public class InformationExtractor {
     private static final String toLocationRetrievalQuery;
     private static final String LAT = "lat";
     private static final String LON = "lon";
+    private static final String NAME = "name";
 
 
     static {
@@ -80,6 +81,50 @@ public class InformationExtractor {
                 double lat = solution.getLiteral(LAT).getDouble();
                 double lon = solution.getLiteral(LON).getDouble();
                 return new DestinationAddress(lon, lat);
+            }
+        }
+        return null;
+    }
+
+    public static String getDestinationName(GoalInstantiationResult payload) {
+        if(payload != null) {
+            QuerySolution solution = executeQuery(toLocationRetrievalQuery, payload.getInstanceModel());
+
+            if (solution != null) {
+                return solution.getLiteral(NAME).getString();
+            }
+        }
+        return null;
+    }
+
+    public static String getDepartureName(GoalInstantiationResult payload) {
+        if(payload != null) {
+            QuerySolution solution = executeQuery(fromLocationRetrievalQuery, payload.getInstanceModel());
+
+            if (solution != null) {
+                return solution.getLiteral(NAME).getString();
+            }
+        }
+        return null;
+    }
+
+    public static String getDestinationName(Model payload){
+        if(payload != null && !payload.isEmpty()) {
+            QuerySolution solution = executeQuery(toLocationRetrievalQuery, payload);
+
+            if (solution != null) {
+                return solution.getLiteral(NAME).getString();
+            }
+        }
+        return null;
+    }
+
+    public static String getDepartureName(Model payload){
+        if(payload != null && !payload.isEmpty()) {
+            QuerySolution solution = executeQuery(fromLocationRetrievalQuery, payload);
+
+            if (solution != null) {
+                return solution.getLiteral(NAME).getString();
             }
         }
         return null;

--- a/won-taxi-bot/src/main/resources/correct/fromLocationRetrieval.rq
+++ b/won-taxi-bot/src/main/resources/correct/fromLocationRetrieval.rq
@@ -1,12 +1,13 @@
 prefix s:     <http://schema.org/>
 
-select ?lat ?lon
+select ?lat ?lon ?name
 
 where {
 	?main a s:TravelAction;
     	  s:fromLocation ?location.
   	?location a s:Place;
-          s:geo ?geo.
+          s:geo ?geo;
+          s:name ?name.
   	?geo a s:GeoCoordinates;
           s:latitude ?lat;
           s:longitude ?lon.

--- a/won-taxi-bot/src/main/resources/correct/goals.trig
+++ b/won-taxi-bot/src/main/resources/correct/goals.trig
@@ -48,6 +48,11 @@ ex2:p2g-shapes {
               sh:maxCount 1 ;
           ] ;
           sh:property [
+              sh:path s:name ;
+              sh:minCount 0 ;
+              sh:maxCount 1 ;
+          ] ;
+          sh:property [
                       sh:path rdf:type;
                       sh:minCount 1;
                   ];

--- a/won-taxi-bot/src/main/resources/correct/toLocationRetrieval.rq
+++ b/won-taxi-bot/src/main/resources/correct/toLocationRetrieval.rq
@@ -1,12 +1,13 @@
 prefix s:     <http://schema.org/>
 
-select ?lat ?lon
+select ?lat ?lon ?name
 
 where {
 	?main a s:TravelAction;
     	  s:toLocation ?location.
   	?location a s:Place;
-          s:geo ?geo.
+          s:geo ?geo;
+          s:name ?name.
   	?geo a s:GeoCoordinates;
           s:latitude ?lat;
           s:longitude ?lon.


### PR DESCRIPTION
fixes [#2353](https://github.com/researchstudio-sat/webofneeds/issues/2353) (of webofneeds issues) -> i just add resilience instead of retrieving the conversation, as the location should be retrievable when a correct proposal structure has been made -> when we can send travelActions via the bot...

in addition to the fix i adapted the sparql info retrieval query and the goal extraction in a way that we also extract the s:name (= address string) from the toLocation and fromLocation in order to have a better message and not send the user a "from coords to coords" message
